### PR TITLE
Fix build for ESP8266 core

### DIFF
--- a/src/at24cxxx.cpp
+++ b/src/at24cxxx.cpp
@@ -2,7 +2,7 @@
 #include "at24cxxx.h"
 #include "Arduino.h"
 
-#define MAX_ALLOWED_LEN_IN_REQUESTFROM (255)
+#define MAX_ALLOWED_LEN_IN_REQUESTFROM ((size_t) 255)
 
 AT24Cxxx::AT24Cxxx(uint8_t address, TwoWire& i2c, int writeDelay, uint16_t size, uint8_t pageSize)  :
   i2cAddress(address), twoWire(&i2c), size(size), writeDelay(writeDelay), pageSize(pageSize) {


### PR DESCRIPTION
When trying to build for a ESP8266 core, this error occurs:
```
/home/username/Arduino/libraries/AT24C/src/at24cxxx.cpp: In member function 'int AT24Cxxx::readBuffer(uint16_t, uint8_t*, size_t)':
/home/username/Arduino/libraries/AT24C/src/at24cxxx.cpp:130:74: error: no matching function for call to 'min(size_t&, int)'
  130 |     size_t bytesToRead = min(lenRemaining, MAX_ALLOWED_LEN_IN_REQUESTFROM);
```

Due to a different implementation of `min()` on the ESP8266 core, it's not allowed to compare different types. Fixed by casting `MAX_ALLOWED_LEN_IN_REQUESTFROM` to `size_t`.